### PR TITLE
Call templates with nice fetch method

### DIFF
--- a/ps_mainmenu.php
+++ b/ps_mainmenu.php
@@ -1422,6 +1422,7 @@ class Ps_MainMenu extends Module implements WidgetInterface
         $this->smarty->assign([
             'menu' => $this->getWidgetVariables($hookName, $configuration)
         ]);
-        return $this->display(__FILE__, 'ps_mainmenu.tpl');
+
+        return $this->fetch('module:ps_mainmenu/ps_mainmenu.tpl');
     }
 }


### PR DESCRIPTION
`$this->display()` should not be used anymore!

Have a look at this: https://github.com/PrestaShop/PrestaShop/pull/6491