### PR TITLE
Fix ids of custom links

### DIFF
--- a/ps_mainmenu.php
+++ b/ps_mainmenu.php
@@ -666,7 +666,7 @@ class Ps_MainMenu extends Module implements WidgetInterface
                         }
                         $root_node['children'][] = $this->makeNode([
                             'type' => 'link',
-                            'page_identifier' => $link[0]['link'],
+                            'page_identifier' => 'lnk-' . Tools::str2url($link[0]['label']),
                             'label' => $link[0]['label'],
                             'url' => $link[0]['link'],
                             'open_in_new_window' => $link[0]['new_window']


### PR DESCRIPTION
The ids shouldn't come from the links but from the labels.

http://forge.prestashop.com/browse/BOOM-1855
http://forge.prestashop.com/browse/BOOM-1916