### PR TITLE
Ps_MenuTopLinks::update number of params mistake

### DIFF
--- a/ps_mainmenu.php
+++ b/ps_mainmenu.php
@@ -275,7 +275,7 @@ class Ps_MainMenu extends Module implements WidgetInterface
                         $label[$lang['id_lang']] = Tools::getValue('label_'.(int)$lang['id_lang']);
                     }
 
-                    Ps_MenuTopLinks::update($link, $label, $new_window, (int)$id_shop, (int)$id_linksmenutop, (int)$id_linksmenutop);
+                    Ps_MenuTopLinks::update($link, $label, $new_window, (int)$id_shop, (int)$id_linksmenutop);
                     $this->_html .= $this->displayConfirmation($this->trans('The link has been edited.', array(), 'Modules.Mainmenu.Admin'));
                 }
                 $update_cache = true;


### PR DESCRIPTION
fix Ps_MenuTopLinks::update call, 6 parameter given, but signature has 5 params