### PR TITLE
Remove separator const from getCacheDirectory

### DIFF
--- a/ps_mainmenu.php
+++ b/ps_mainmenu.php
@@ -942,7 +942,7 @@ class Ps_MainMenu extends Module implements WidgetInterface
 
     protected function getCacheDirectory()
     {
-        return _PS_CACHE_DIR_ . DIRECTORY_SEPARATOR . 'ps_mainmenu';
+        return _PS_CACHE_DIR_ . 'ps_mainmenu';
     }
 
     protected function clearMenuCache()


### PR DESCRIPTION
Separator is already include in constant, cause no json file is created.