### PR TITLE
Take user groups into account when rendering menu

### DIFF
--- a/ps_mainmenu.php
+++ b/ps_mainmenu.php
@@ -1396,7 +1396,9 @@ class Ps_MainMenu extends Module implements WidgetInterface
         $id_lang = $this->context->language->id;
         $id_shop = $this->context->shop->id;
 
-        $key = self::MENU_JSON_CACHE_KEY . '_' . $id_lang . '_' . $id_shop . '.json';
+        $this->user_groups = Customer::getGroupsStatic($this->context->customer->id);
+        $groupsKey = empty($this->user_groups) ? '' : '_' . join("_", $this->user_groups);
+        $key = self::MENU_JSON_CACHE_KEY . '_' . $id_lang . '_' . $id_shop . $groupsKey . '.json';
         $cacheDir = $this->getCacheDirectory();
         $cacheFile = $cacheDir . DIRECTORY_SEPARATOR . $key;
         $menu = json_decode(@file_get_contents($cacheFile), true);


### PR DESCRIPTION
When a category access is restricted by user group, the category is still displayed in the menu, even if the user is not a member of one of those group. It is described here : https://github.com/PrestaShop/PrestaShop/issues/9924
There has been 2 different corrections that have been proposed on this thread, but none of them has been merged in the module (there is some commits for at least one proposition in the dev branch, but not in master branch).
I think my changes are a bit simpler. I simply initialize the "user_groups" property that was already defined in the Ps_MainMenu class, but never initialized. This property was already used in the function makeMenu to restrict category list to only those accessible for the user.
So I only initialize the property, and use it to create the cache key for the menu.