### PR TITLE
Unused $children param

### DIFF
--- a/ps_mainmenu.php
+++ b/ps_mainmenu.php
@@ -712,7 +712,7 @@ class Ps_MainMenu extends Module implements WidgetInterface
         return $html;
     }
 
-    protected function generateCategoriesMenu($categories, $is_children = 0)
+    protected function generateCategoriesMenu($categories)
     {
         $nodes = [];
 
@@ -744,7 +744,7 @@ class Ps_MainMenu extends Module implements WidgetInterface
             $node['image_urls']  = [];
 
             if (isset($category['children']) && !empty($category['children'])) {
-                $node['children'] = $this->generateCategoriesMenu($category['children'], 1);
+                $node['children'] = $this->generateCategoriesMenu($category['children']);
 
                 if ($this->imageFiles === null) {
                     $this->imageFiles = scandir(_PS_CAT_IMG_DIR_);


### PR DESCRIPTION
Unused $children param in the generateCategoriesMenu() core

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
