### PR TITLE
getCMSCategories() depend on shop

### DIFF
--- a/ps_mainmenu.php
+++ b/ps_mainmenu.php
@@ -483,7 +483,7 @@ class Ps_MainMenu extends Module implements WidgetInterface
     {
         $category = new CMSCategory($id_cms_category, $id_lang);
 
-        $rawSubCategories = $this->getCMSCategories(false, $id_cms_category, $id_lang);
+        $rawSubCategories = $this->getCMSCategories(false, $id_cms_category, $id_lang, (int)$id_shop);
         $rawSubPages = $this->getCMSPages($id_cms_category);
 
         $subCategories = array_map(function ($category) use ($id_lang) {


### PR DESCRIPTION
getCMSCategories() depend on shop

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
