### PR TITLE
Fix PHP 8 compatibility

### DIFF
--- a/ps_menutoplinks.class.php
+++ b/ps_menutoplinks.class.php
@@ -26,7 +26,7 @@
 
 class Ps_MenuTopLinks
 {
-    public static function gets($id_lang, $id_linksmenutop = null, $id_shop)
+    public static function gets($id_lang, $id_linksmenutop = null, $id_shop = 0)
     {
         $sql = 'SELECT l.id_linksmenutop, l.new_window, s.name, ll.link, ll.label
 				FROM '._DB_PREFIX_.'linksmenutop l
@@ -67,7 +67,7 @@ class Ps_MenuTopLinks
         return array('link' => $link, 'label' => $label, 'new_window' => $new_window);
     }
 
-    public static function add($link, $label, $newWindow = 0, $id_shop)
+    public static function add($link, $label, $newWindow = 0, $id_shop = 0)
     {
         if (!is_array($label)) {
             return false;
@@ -103,7 +103,7 @@ class Ps_MenuTopLinks
         return $result;
     }
 
-    public static function update($link, $labels, $newWindow = 0, $id_shop, $id_link)
+    public static function update($link, $labels, $newWindow = 0, $id_shop = 0, $id_link = 0)
     {
         if (!is_array($labels)) {
             return false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | function arguments that come after an optional one should be optional as well in order to be compatible with PHP 8.
| Type?         | bug fix
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No test need AFAIK

### BC Break
- The static function `gets` now has a default value on the third argument.
- The static function `add` now has a default value on the third argument.
- The static function `update` now has a default value on the third & fourth argument

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
