### PR TITLE
Fix display of the thr first column in configure main menu screen

### DIFF
--- a/views/templates/admin/_configure/helpers/form/form.tpl
+++ b/views/templates/admin/_configure/helpers/form/form.tpl
@@ -98,7 +98,7 @@ function move(up)
 {block name="input"}
     {if $input.type == 'link_choice'}
 	    <div class="row">
-	    	<div class="col-lg-1">
+	    	<div class="col-lg-1" style="min-width: 4rem">
 	    		<h4 style="margin-top:5px;">{l s='Change position' d='Modules.Mainmenu.Admin'}</h4>
                 <a href="#" id="menuOrderUp" class="btn btn-default" style="font-size:20px;display:block;"><i class="icon-chevron-up"></i></a><br/>
                 <a href="#" id="menuOrderDown" class="btn btn-default" style="font-size:20px;display:block;"><i class="icon-chevron-down"></i></a><br/>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | 'Change position' label in Modules/ps_mainmenu/Configure has no enough space and next columns overlay it
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/26054
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
