### PR TITLE
Replace deprecated CHARSET utf8 in installDb

### DIFF
--- a/ps_mainmenu.php
+++ b/ps_mainmenu.php
@@ -124,7 +124,7 @@ class Ps_MainMenu extends Module implements WidgetInterface
 			`id_shop` INT(11) UNSIGNED NOT NULL,
 			`new_window` TINYINT( 1 ) NOT NULL,
 			INDEX (`id_shop`)
-		) ENGINE = ' . _MYSQL_ENGINE_ . ' CHARACTER SET utf8 COLLATE utf8_general_ci;') &&
+		) ENGINE = ' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8mb4;') &&
             Db::getInstance()->execute('
 			 CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'linksmenutop_lang` (
 			`id_linksmenutop` INT(11) UNSIGNED NOT NULL,
@@ -133,7 +133,7 @@ class Ps_MainMenu extends Module implements WidgetInterface
 			`label` VARCHAR( 128 ) NOT NULL ,
 			`link` VARCHAR( 128 ) NOT NULL ,
 			INDEX ( `id_linksmenutop` , `id_lang`, `id_shop`)
-		) ENGINE = ' . _MYSQL_ENGINE_ . ' CHARACTER SET utf8 COLLATE utf8_general_ci;');
+		) ENGINE = ' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8mb4;');
     }
 
     public function uninstall($delete_params = true)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Just follow Prestashop Core / install / data / db_structure.sql rule
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | Fixes PrestaShop/PrestaShop#28857
| How to test?  | Check linksmenutop and linksmenutop_lang tables before PR with phpmyadmin you will see Collation = ---

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
