### PR TITLE
Fixing a small but serious bug preventing update links

### DIFF
--- a/ps_menutoplinks.class.php
+++ b/ps_menutoplinks.class.php
@@ -124,11 +124,10 @@ class Ps_MenuTopLinks
             Db::getInstance()->update(
                 'linksmenutop_lang',
                 [
-                    'id_shop' => (int) $id_shop,
                     'label' => pSQL($label),
                     'link' => pSQL($link[$id_lang]),
                 ],
-                'id_linksmenutop = ' . (int) $id_link . ' AND id_lang = ' . (int) $id_lang
+                'id_linksmenutop = ' . (int) $id_link . ' AND id_lang = ' . (int) $id_lang . ' AND id_shop = ' . (int) $id_shop
             );
         }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Cannot update a link in Main Menu module at all! How long this small typo was in?
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |  Go to Main Menu configuration, click on Edit button on Link List, update details (Label or Link) in the form above, press Update - the link is not updated! I wonder, was it there from the very start? I think it was added when implementing multi-shop feature - how many decades ago?

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
![Screenshot 2023-01-07 213806](https://user-images.githubusercontent.com/12764829/211171296-2027cae4-6188-4afd-b7cd-1e54e4695824.png)
