### PR TITLE
Add hook actionMainMenuModifier

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_mainmenu</name>
 	<displayName><![CDATA[Main menu]]></displayName>
-	<version><![CDATA[2.3.4]]></version>
+	<version><![CDATA[2.3.5]]></version>
 	<description><![CDATA[Adds a new menu to the top of your e-commerce website.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[front_office_features]]></tab>

--- a/ps_mainmenu.php
+++ b/ps_mainmenu.php
@@ -69,7 +69,7 @@ class Ps_MainMenu extends Module implements WidgetInterface
     {
         $this->name = 'ps_mainmenu';
         $this->tab = 'front_office_features';
-        $this->version = '2.3.4';
+        $this->version = '2.3.5';
         $this->author = 'PrestaShop';
         $this->imageFiles = null;
 
@@ -136,7 +136,10 @@ class Ps_MainMenu extends Module implements WidgetInterface
 			`label` VARCHAR( 128 ) NOT NULL ,
 			`link` VARCHAR( 128 ) NOT NULL ,
 			INDEX ( `id_linksmenutop` , `id_lang`, `id_shop`)
-		) ENGINE = ' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8mb4;');
+		) ENGINE = ' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8mb4;') &&
+            Db::getInstance()->execute('
+            INSERT IGNORE INTO `' . _DB_PREFIX_ . 'hook` (`name`, `title`, `description`) VALUES
+            (\'actionMainMenuModifier\', \'Modify main menu view data\', \'This hook allows to alter main menu data\');');
     }
 
     public function uninstall($delete_params = true)
@@ -1489,8 +1492,12 @@ class Ps_MainMenu extends Module implements WidgetInterface
 
     public function renderWidget($hookName, array $configuration)
     {
+        $menu = $this->getWidgetVariables($hookName, $configuration);
+
+        Hook::exec('actionMainMenuModifier', ['menu' => &$menu]);
+
         $this->smarty->assign([
-            'menu' => $this->getWidgetVariables($hookName, $configuration),
+            'menu' => $menu,
         ]);
 
         return $this->fetch('module:ps_mainmenu/ps_mainmenu.tpl');

--- a/upgrade/upgrade-2.3.5.php
+++ b/upgrade/upgrade-2.3.5.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_3_5($module)
+{
+    return Db::getInstance()->execute('INSERT IGNORE INTO `' . _DB_PREFIX_ . "hook` (`name`, `title`, `description`) VALUES
+        ('actionMainMenuModifier', 'Modify main menu view data', 'This hook allows to alter main menu data')");
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Allow main menu to be extended by other modules thanks a new hook `actionMainMenuModifier`. <br/>Thanks this hook it's possible to have menu items specific per customer by example.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | No issue
| How to test?  | Register hook `actionMainMenuModifier` and add or edit something into main menu

Hook usage :
```
    public function hookActionMainMenuModifier(array $hookParams)
    {
          $hookParams['menu']['children'][] = [
              'type' => 'link',
              'label' => $this->trans('Test', [], 'Modules.Test.Menu'),
              'url' => $this->context->link->getModuleLink($this->name, 'pickup'),
              'depth' => 1,
              'children' => [],
              'open_in_new_window' => "0",
              'page_identifier' => $this->trans('Test', [], 'Modules.Test.Menu'),
              'current' => false
          ];
    }
```
