### PR TITLE
Fix: Schema of URLs of category route does not redirect to the right page

### DIFF
--- a/ps_mainmenu.php
+++ b/ps_mainmenu.php
@@ -100,6 +100,7 @@ class Ps_MainMenu extends Module implements WidgetInterface
             !$this->registerHook('actionObjectProductDeleteAfter') ||
             !$this->registerHook('actionObjectProductAddAfter') ||
             !$this->registerHook('actionCategoryUpdate') ||
+            !$this->registerHook('actionMetaPageSave') ||
             !$this->registerHook('actionShopDataDuplication') ||
             !$this->registerHook('displayTop')) {
             return false;
@@ -986,6 +987,11 @@ class Ps_MainMenu extends Module implements WidgetInterface
     }
 
     public function hookActionCategoryUpdate($params)
+    {
+        $this->clearMenuCache();
+    }
+
+    public function hookActionMetaPageSave($params)
     {
         $this->clearMenuCache();
     }

--- a/upgrade/upgrade-2.3.5.php
+++ b/upgrade/upgrade-2.3.5.php
@@ -24,5 +24,6 @@ if (!defined('_PS_VERSION_')) {
 function upgrade_module_2_3_5($module)
 {
     return Db::getInstance()->execute('INSERT IGNORE INTO `' . _DB_PREFIX_ . "hook` (`name`, `title`, `description`) VALUES
-        ('actionMainMenuModifier', 'Modify main menu view data', 'This hook allows to alter main menu data')");
+        ('actionMainMenuModifier', 'Modify main menu view data', 'This hook allows to alter main menu data')")
+        && $module->registerHook('actionMetaPageSave');
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | see: https://github.com/PrestaShop/PrestaShop/issues/38697
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#38697.
| How to test?  | In _Shop Parameters > Traffic & SEO,_ set the **Route to category** field to **{id}**, then go to the front office, click on a category in the menu, and verify that the category is displayed correctly.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
