### PR TITLE
fix : fatal error when _PS_CAT_IMG_DIR_ folder does not exists

### DIFF
--- a/ps_mainmenu.php
+++ b/ps_mainmenu.php
@@ -795,6 +795,9 @@ class Ps_MainMenu extends Module implements WidgetInterface
 
             if ($this->imageFiles === null) {
                 $this->imageFiles = scandir(_PS_CAT_IMG_DIR_);
+		if(false === $this->imageFiles) {
+                    $this->imageFiles = [];
+                }
             }
 
             if (count(preg_grep('/^' . $category['id_category'] . '-([0-9])?_thumb.jpg/i', $this->imageFiles)) > 0) {


### PR DESCRIPTION
Hello !


| Questions | Answers |
| :--- | :--- |
| **Description?** | The `scandir()` PHP function can return `false` if the path does not exist or is not a directory (e.g., due to permission issues). In the current code, this `false` value is passed directly to `preg_grep()`, which expects its second argument to be an array. This causes a `TypeError: preg_grep(): Argument #2 ($array) must be of type array, bool given`.<br><br>This PR adds a check to verify the return value of `scandir()`. If it returns `false`, the property `$this->imageFiles` is initialized as an empty array `[]`. 
| **Type?** | bug fix |
| **BC breaks?** | no |
| **Deprecations?** | no |
| **How to test?** | This bug appears when the category image directory (`/img/c/`) is missing or not readable when generating the module widget variables.
