### PR TITLE
fix: avoid $currentIndex

### DIFF
--- a/ps_mainmenu.php
+++ b/ps_mainmenu.php
@@ -1432,7 +1432,7 @@ class Ps_MainMenu extends Module implements WidgetInterface
         $helper->module = $this;
         $helper->title = $this->trans('Link list', [], 'Modules.Mainmenu.Admin');
         $helper->token = Tools::getAdminTokenLite('AdminModules');
-        $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', true) . '&configure=' . $this->name;
 
         return $helper->generateList($links, $fields_list);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Avoid $currentIndex in URL
| Type?             | improvement 
| BC breaks?        | no
| Deprecations?     | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
